### PR TITLE
fix: use type-only re-export for CallInfo in aqua-sdk and swap-vm-sdk

### DIFF
--- a/typescript/aqua/src/index.ts
+++ b/typescript/aqua/src/index.ts
@@ -3,4 +3,5 @@
 export * from './aqua-protocol-contract'
 export * as ABI from './abi'
 
-export { Address, HexString, NetworkEnum, CallInfo } from '@1inch/sdk-core'
+export { Address, HexString, NetworkEnum } from '@1inch/sdk-core'
+export type { CallInfo } from '@1inch/sdk-core'

--- a/typescript/swap-vm/src/index.ts
+++ b/typescript/swap-vm/src/index.ts
@@ -4,4 +4,5 @@ export * from './swap-vm-contract'
 export * from './swap-vm'
 
 export * as ABI from './abi'
-export { Address, HexString, NetworkEnum, CallInfo } from '@1inch/sdk-core'
+export { Address, HexString, NetworkEnum } from '@1inch/sdk-core'
+export type { CallInfo } from '@1inch/sdk-core'


### PR DESCRIPTION
## Summary

- `CallInfo` in `@1inch/sdk-core` is a TypeScript type alias (no runtime value), but both `aqua-sdk` and `swap-vm-sdk` re-exported it as a value export, causing bundlers to emit `CallInfo` into runtime bundles and fail when no binding exists
- Split the barrel export in both packages: `export { Address, HexString, NetworkEnum }` (runtime) + `export type { CallInfo }` (type-only)
- This eliminates the need for `patchedDependencies` in downstream consumers (e.g. `1inch.com` currently patches `sdk-core` to inject a dummy `CallInfo` runtime binding)

## Changes

| File | Change |
|---|---|
| `typescript/aqua/src/index.ts` | Split `CallInfo` into `export type { CallInfo }` |
| `typescript/swap-vm/src/index.ts` | Split `CallInfo` into `export type { CallInfo }` |

## Verification

- **aqua build**: passes, `CallInfo` absent from `dist/index.mjs`, present in `dist/index.d.ts`
- **swap-vm build**: has a pre-existing `rolldown-plugin-dts` failure with `unbundle: true` (fails identically on `master`) — unrelated to this change
- Non-breaking for consumers already using `import type { CallInfo }` or `const x: CallInfo = ...`

## Test plan

- [x] Verify `CallInfo` absent from aqua ESM runtime bundle
- [x] Verify `CallInfo` present in aqua `.d.ts` type declarations
- [x] Verify `Address`, `HexString`, `NetworkEnum` still present as runtime exports
- [ ] After publish: remove `patchedDependencies` from `1inch.com` and verify build


Made with [Cursor](https://cursor.com)