### PR TITLE
fix(swap-vm): single-sided fromPriceBounds throws at max bound

### DIFF
--- a/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.test.ts
+++ b/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.test.ts
@@ -383,6 +383,63 @@ describe('PriceRange', () => {
       ).toThrow('provided reserve for unknown token')
     })
 
+    describe('single-sided compositions (DAPP-4462 repro: WBTC 8dp / USDT 6dp)', () => {
+      const WBTC = new Address('0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599')
+      const USDT = new Address('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+
+      /** WBTC has the lower address, so it is token0 and USDT is token1. */
+      const WBTC_TOKEN: PriceToken = { address: WBTC, decimals: 8n }
+      const USDT_TOKEN: PriceToken = { address: USDT, decimals: 6n }
+      const pairUsdtQuoteWbtcBase = pricePair(USDT_TOKEN, WBTC_TOKEN)
+
+      /** Range 58,946 -> 63,752 USDT per WBTC. */
+      const wbtcUsdtBounds = (): PriceBounds => ({
+        minPrice: Price.fromHuman('58946', pairUsdtQuoteWbtcBase),
+        maxPrice: Price.fromHuman('63752', pairUsdtQuoteWbtcBase),
+      })
+
+      it('should accept token0-only reserves (spot at min bound)', () => {
+        const { minPrice, maxPrice } = wbtcUsdtBounds()
+
+        const range = PriceRange.fromPriceBounds(
+          { minPrice, maxPrice },
+          {
+            /** 0.442142 WBTC */
+            reserveA: TokenReserve.new({ token: WBTC, reserve: 44214200n }),
+            reserveB: TokenReserve.new({ token: USDT, reserve: 0n }),
+          },
+        )
+
+        expect(range.spotPrice.gte(range.minPrice)).toBe(true)
+        expect(range.spotPrice.lte(range.maxPrice)).toBe(true)
+        expect(range.spotPrice.toHuman(USDT)).toBe('58946.000012')
+      })
+
+      it('should accept token1-only reserves (spot at max bound)', () => {
+        const { minPrice, maxPrice } = wbtcUsdtBounds()
+
+        /**
+         * Mirror of the min-side case above. In exact arithmetic the implied spot equals the
+         * max bound (amount0 = 0), but integer truncation in `computeLiquidityAndPrice`
+         * (`virtualLt = L / sqrtPmax` rounds down) lands the derived `sqrtSpot` ~3.4e-10
+         * (relative) above `sqrtPmax`, and the `PriceRange` constructor assert rejects this
+         * legitimate single-sided composition with 'maxPrice should be >= spotPrice'.
+         */
+        const range = PriceRange.fromPriceBounds(
+          { minPrice, maxPrice },
+          {
+            reserveA: TokenReserve.new({ token: WBTC, reserve: 0n }),
+            /** 28,207 USDT */
+            reserveB: TokenReserve.new({ token: USDT, reserve: 28_207_000_000n }),
+          },
+        )
+
+        expect(range.spotPrice.gte(range.minPrice)).toBe(true)
+        expect(range.spotPrice.lte(range.maxPrice)).toBe(true)
+        expect(range.spotPrice.equals(range.maxPrice)).toBe(true)
+      })
+    })
+
     describe('spot recovery after allocation', () => {
       const maxUsdc = 1_000_000n * 10n ** 6n
       const maxWeth = 400n * 10n ** 18n

--- a/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.test.ts
+++ b/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.test.ts
@@ -398,7 +398,7 @@ describe('PriceRange', () => {
         maxPrice: Price.fromHuman('63752', pairUsdtQuoteWbtcBase),
       })
 
-      it('should accept token0-only reserves (spot at min bound)', () => {
+      it('should place spot exactly at the min bound for token0-only reserves', () => {
         const { minPrice, maxPrice } = wbtcUsdtBounds()
 
         const range = PriceRange.fromPriceBounds(
@@ -410,20 +410,20 @@ describe('PriceRange', () => {
           },
         )
 
-        expect(range.spotPrice.gte(range.minPrice)).toBe(true)
-        expect(range.spotPrice.lte(range.maxPrice)).toBe(true)
-        expect(range.spotPrice.toHuman(USDT)).toBe('58946.000012')
+        expect(range.spotPrice.equals(range.minPrice)).toBe(true)
+        expect(range.spotPrice.toHuman(USDT)).toBe('58946')
       })
 
-      it('should accept token1-only reserves (spot at max bound)', () => {
+      it('should place spot exactly at the max bound for token1-only reserves', () => {
         const { minPrice, maxPrice } = wbtcUsdtBounds()
 
         /**
          * Mirror of the min-side case above. In exact arithmetic the implied spot equals the
-         * max bound (amount0 = 0), but integer truncation in `computeLiquidityAndPrice`
-         * (`virtualLt = L / sqrtPmax` rounds down) lands the derived `sqrtSpot` ~3.4e-10
-         * (relative) above `sqrtPmax`, and the `PriceRange` constructor assert rejects this
+         * max bound (amount0 = 0), but deriving it via `computeLiquidityAndPrice` truncates
+         * (`virtualLt = L / sqrtPmax` rounds down), landing the derived `sqrtSpot` ~3.4e-10
+         * (relative) above `sqrtPmax` so the constructor assert used to reject this
          * legitimate single-sided composition with 'maxPrice should be >= spotPrice'.
+         * Single-sided compositions now short-circuit to the corresponding bound.
          */
         const range = PriceRange.fromPriceBounds(
           { minPrice, maxPrice },
@@ -434,9 +434,22 @@ describe('PriceRange', () => {
           },
         )
 
-        expect(range.spotPrice.gte(range.minPrice)).toBe(true)
-        expect(range.spotPrice.lte(range.maxPrice)).toBe(true)
         expect(range.spotPrice.equals(range.maxPrice)).toBe(true)
+        expect(range.spotPrice.toHuman(USDT)).toBe('63752')
+      })
+
+      it('should throw when both reserves are zero', () => {
+        const { minPrice, maxPrice } = wbtcUsdtBounds()
+
+        expect(() =>
+          PriceRange.fromPriceBounds(
+            { minPrice, maxPrice },
+            {
+              reserveA: TokenReserve.new({ token: WBTC, reserve: 0n }),
+              reserveB: TokenReserve.new({ token: USDT, reserve: 0n }),
+            },
+          ),
+        ).toThrow('at least one reserve must be positive')
       })
     })
 

--- a/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.ts
+++ b/typescript/swap-vm/src/swap-vm/instructions/concentrate/price-range/price-range.ts
@@ -71,6 +71,19 @@ export class PriceRange {
       'provided reserve for unknown token',
     )
 
+    assert(reserve0.reserve > 0n || reserve1.reserve > 0n, 'at least one reserve must be positive')
+
+    // Single-sided composition: the spot sits exactly on a bound (reserve0 depletes at max,
+    // reserve1 at min). Deriving it via computeLiquidityAndPrice would reintroduce integer
+    // truncation that can land the implied sqrt spot just outside the bounds.
+    if (reserve0.reserve === 0n) {
+      return PriceRange.new({ minPrice, spotPrice: maxPrice, maxPrice })
+    }
+
+    if (reserve1.reserve === 0n) {
+      return PriceRange.new({ minPrice, spotPrice: minPrice, maxPrice })
+    }
+
     const { sqrtPriceSpot } = computeLiquidityAndPrice(
       reserve0.reserve,
       reserve1.reserve,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the asymmetric edge case in `PriceRange.fromPriceBounds` reported in [1inch/dapp-ui#3938](https://github.com/1inch/dapp-ui/issues/3938) (found while fixing DAPP-4462, [1inch/dapp-ui#3954](https://github.com/1inch/dapp-ui/pull/3954)), together with regression tests that reproduce it.

## The bug

For a valid single-sided composition at the **max** bound, `fromPriceBounds` threw `maxPrice should be >= spotPrice`, while the mirror case at the **min** bound round-tripped fine.

Repro (WBTC 8dp / USDT 6dp, range 58,946 → 63,752 USDT per WBTC):

- `reserveLt = 0.442142 WBTC, reserveGt = 0` → implied spot 58,946.000012 ✅ (min side OK, but off by rounding dust)
- `reserveLt = 0, reserveGt = 28,207 USDT` → throws ❌

In exact arithmetic the implied spot equals the max bound (`amount0 = 0`), but integer truncation in `computeLiquidityAndPrice` (`virtualLt = L / sqrtPmax` rounds down) lands the derived `sqrtSpot` ~3.4e-10 (relative) above `sqrtPmax`, and the `PriceRange` constructor assert rejects the legitimate composition.

## The fix

For single-sided compositions the spot is a bound **by construction** (`bLt = L·(√Pmax − √Pspot)/… = 0 ⟺ spot = max`; `bGt = L·(√Pspot − √Pmin) = 0 ⟺ spot = min`), so `fromPriceBounds` now short-circuits:

- `reserve0 == 0` → `spotPrice = maxPrice`
- `reserve1 == 0` → `spotPrice = minPrice`
- both zero → explicit `at least one reserve must be positive` assert (previously a cryptic `mulDiv: division by zero` from deep inside the math)

No math is run for these cases, so no truncation dust — the spot is exactly the bound on both sides now (the min side previously came out at 58,946.000012 instead of 58,946). The constructor assert stays untouched. The both-reserves-positive path is unchanged.

## Tests

Added under `fromPriceBounds > single-sided compositions`:

- token0-only reserves → spot exactly at min bound (`58946`)
- token1-only reserves → spot exactly at max bound (`63752`) — this was the throwing case
- both reserves zero → throws `at least one reserve must be positive`

```
Test Files  44 passed (44)
     Tests  595 passed (595)
```

Lint and type-check pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e3436c9-5793-45db-851a-7c8c0ec3f9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e3436c9-5793-45db-851a-7c8c0ec3f9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

