### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo (`@1inch/sdks`) is a **pnpm + Nx monorepo of TypeScript SDK libraries** (not runnable apps):
+`@1inch/sdk-core`, `@1inch/aqua-sdk`, `@1inch/swap-vm-sdk` (all under `typescript/`).
+"Running" the product means building the packages and exercising the test suites; the e2e suites
+execute real swaps against a local Anvil mainnet fork.
+
+Standard commands live in the root `package.json` scripts and `README.md`; prefer those. Key ones:
+`pnpm build`, `pnpm lint`, `pnpm lint:types`, `pnpm test` (unit), `pnpm test:e2e`.
+
+Non-obvious caveats for this environment:
+
+- **Foundry is required and preinstalled** in this VM (at `~/.foundry/bin`, already on `PATH` via
+  `~/.bashrc`). `forge`/`anvil` are available in login shells.
+- **Build contracts before lint/type-check/test.** Run `pnpm build:contracts` (`forge build`) first —
+  it generates the `dist/contracts` ABIs that the TypeScript sources import via `@contracts/*`.
+  Lint, type-check, and (indirectly) tests fail without it. `dist/contracts` is gitignored, so rebuild
+  after pulling contract changes.
+- **e2e tests need Docker running.** Docker is preinstalled but the daemon is NOT auto-started. Start it
+  once per session, e.g. `sudo dockerd &` (or in a tmux session). The `ubuntu` user is in the `docker`
+  group, so in a fresh login shell `docker` works without sudo; within an already-open shell you may need
+  `sg docker -c '<cmd>'` for the group membership to apply. e2e uses `testcontainers` to launch
+  `ghcr.io/foundry-rs/foundry:v1.2.3` (Anvil) forked from Ethereum mainnet.
+- **Set a working `FORK_URL` for e2e.** The default fork RPC hardcoded in the tests
+  (`https://eth.llamarpc.com`) is frequently down (HTTP 521). Override it, e.g.
+  `FORK_URL=https://ethereum-rpc.publicnode.com pnpm test:e2e`. Optional `FORK_HEADER` also supported.
+- **A few `swap-vm` e2e tests assert exact floating-point prices** derived from the live mainnet fork
+  state (the 2000–3000 concentrated-range tests and the 30bps-fee test). They can differ at the ~13th
+  significant digit depending on the fork block / RPC provider, independent of any code change. The
+  `aqua` e2e suite (3/3) is deterministic.
+- The ESM build of `swap-vm` (`dist/index.mjs`) currently fails to import under strict Node ESM because a
+  transitive dep (`@1inch/byte-utils`) uses an extensionless import; the CJS entry (`dist/index.js`) and
+  the bundled/test toolchains work fine. Prefer the CJS entry for quick standalone Node scripts.

--- a/nx.json
+++ b/nx.json
@@ -40,6 +40,11 @@
         "{workspaceRoot}/typescript/eslint.config.mjs"
       ]
     },
+    "type-check": {
+      "dependsOn": [
+        "^build"
+      ]
+    },
     "test:e2e": {
       "inputs": [
         "default",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the development environment for the `@1inch/sdks` monorepo, documents non-obvious startup caveats for future cloud agents in a new `AGENTS.md`, and fixes a latent CI type-check failure.

This repo is a pnpm + Nx monorepo of TypeScript SDK libraries (`@1inch/sdk-core`, `@1inch/aqua-sdk`, `@1inch/swap-vm-sdk`). There is no runnable app server; "running the product" means building the packages and exercising the test suites, whose e2e suites execute real swaps against a local Anvil mainnet fork.

## Changes
- **`AGENTS.md`** — Cursor Cloud setup/run caveats (Foundry preinstalled, build contracts before lint/test, start dockerd for e2e, `FORK_URL` override, fork-sensitive e2e assertions).
- **`nx.json`** — add `dependsOn: ["^build"]` to the `type-check` target so `pnpm lint:types` builds workspace dependencies first.

## Why the `nx.json` fix
`typescript/aqua/tsconfig.json` overrides `baseUrl` to `./src`, which breaks the inherited `paths` mapping for `@1inch/sdk-core`; it then falls back to `node_modules` → `sdk-core/dist/*.d.ts`, which only exists after a build. CI runs `pnpm affected:build` (which builds nothing for a docs-only PR) and then full `pnpm lint:types`, so `aqua:type-check` failed with `Cannot find module '@1inch/sdk-core'`. Declaring `^build` on `type-check` makes `pnpm lint:types` self-sufficient regardless of what was prebuilt. No product/runtime behavior changes.

## Environment set up (persisted in the VM snapshot)
- `pnpm install` (Node 22 / pnpm 10.22)
- Foundry (`forge`/`anvil`) via `foundryup`, on `PATH`
- Docker engine (for `testcontainers`-driven Anvil fork)
- `pnpm build:contracts` (`forge build`) to generate `dist/contracts` ABIs

Update script (runs on VM startup): `pnpm install`.

## Verification
| Check | Result |
|---|---|
| `pnpm build` | ✅ 3 projects built |
| `pnpm lint` | ✅ pass |
| `pnpm lint:types` (from clean, no prebuild) | ✅ pass (builds deps first) |
| `pnpm test` (unit) | ✅ 3 projects pass |
| `pnpm test:e2e` (aqua) | ✅ 3/3 pass |
| `pnpm test:e2e` (swap-vm) | ⚠️ 10/13 pass; 3 fail on exact-float price assertions tied to live mainnet fork block/state (see below) |
| hello-world SDK consumer | ✅ built programs, created orders, computed EIP-712 hashes, encoded orders |

## Notes
- The tests' default fork RPC (`https://eth.llamarpc.com`) is down (HTTP 521); e2e requires `FORK_URL` override, e.g. `FORK_URL=https://ethereum-rpc.publicnode.com`.
- The 3 failing `swap-vm` concentrated/fee e2e tests assert exact floating-point prices derived from the live mainnet fork state; they differ at the ~13th significant digit depending on the fork block/provider, independent of any code change.

[aqua_e2e_pass.log](https://cursor.com/artifacts/c/art-f1a8869c-887a-4ee6-be15-9660efc2ff64)
[hello_world_sdk_demo.log](https://cursor.com/artifacts/c/art-d7cf6adc-260f-4b9c-8d50-69850344bcbe)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1f55ca0-436f-414a-ac29-b270c573eb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1f55ca0-436f-414a-ac29-b270c573eb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

