### PR TITLE
feat: add Robinhood Chain (4663) contract addresses for Aqua and SwapVM

### DIFF
--- a/typescript/aqua/README.md
+++ b/typescript/aqua/README.md
@@ -200,6 +200,7 @@ The SDK includes pre-configured contract addresses for the following networks:
 | Linea | 59144 | [0x4a055aa172c98ec32de118b9b5b6ac8b4099a580](https://lineascan.build/address/0x4a055aa172c98ec32de118b9b5b6ac8b4099a580) |
 | Unichain | 1301 | [0x4a055aa172c98ec32de118b9b5b6ac8b4099a580](https://uniscan.xyz/address/0x4a055aa172c98ec32de118b9b5b6ac8b4099a580) |
 | Sonic | 146 | [0x4a055aa172c98ec32de118b9b5b6ac8b4099a580](https://sonicscan.org/address/0x4a055aa172c98ec32de118b9b5b6ac8b4099a580) |
+| Robinhood Chain | 4663 | [0x7c2d4aa5c900c08004fadb1c0d953c5b099fec86](https://robinhoodchain.blockscout.com/address/0x7c2d4aa5c900c08004fadb1c0d953c5b099fec86) |
 
 Access addresses using:
 

--- a/typescript/aqua/src/aqua-protocol-contract/constants.ts
+++ b/typescript/aqua/src/aqua-protocol-contract/constants.ts
@@ -18,4 +18,5 @@ export const AQUA_CONTRACT_ADDRESSES: Record<NetworkEnum, Address> = {
   [NetworkEnum.LINEA]: new Address('0x4a055aa172c98ec32de118b9b5b6ac8b4099a580'),
   [NetworkEnum.UNICHAIN]: new Address('0x4a055aa172c98ec32de118b9b5b6ac8b4099a580'),
   [NetworkEnum.SONIC]: new Address('0x4a055aa172c98ec32de118b9b5b6ac8b4099a580'),
+  [NetworkEnum.ROBINHOOD]: new Address('0x7c2d4aa5c900c08004fadb1c0d953c5b099fec86'),
 }

--- a/typescript/sdk-core/src/types/chain.ts
+++ b/typescript/sdk-core/src/types/chain.ts
@@ -11,4 +11,5 @@ export enum NetworkEnum {
   LINEA = 59144,
   SONIC = 146,
   UNICHAIN = 130,
+  ROBINHOOD = 4663,
 }

--- a/typescript/swap-vm/README.md
+++ b/typescript/swap-vm/README.md
@@ -535,6 +535,7 @@ The SDK includes pre-configured contract addresses of `AquaSwapVMRouter` for the
 | Linea | 59144 | [0x3c4758979ec30ca45857cabc2462a70699ed790e](https://lineascan.build/address/0x3c4758979ec30ca45857cabc2462a70699ed790e) |
 | Unichain | 1301 | [0x3c4758979ec30ca45857cabc2462a70699ed790e](https://uniscan.xyz/address/0x3c4758979ec30ca45857cabc2462a70699ed790e) |
 | Sonic | 146 | [0x3c4758979ec30ca45857cabc2462a70699ed790e](https://sonicscan.org/address/0x3c4758979ec30ca45857cabc2462a70699ed790e) |
+| Robinhood Chain | 4663 | [0x3c4758979ec30ca45857cabc2462a70699ed790e](https://robinhoodchain.blockscout.com/address/0x3c4758979ec30ca45857cabc2462a70699ed790e) |
 
 Access addresses using:
 

--- a/typescript/swap-vm/src/swap-vm-contract/constants.ts
+++ b/typescript/swap-vm/src/swap-vm-contract/constants.ts
@@ -30,4 +30,5 @@ export const AQUA_SWAP_VM_CONTRACT_ADDRESSES: Record<NetworkEnum, Address> = {
   [NetworkEnum.LINEA]: new Address('0x3c4758979ec30ca45857cabc2462a70699ed790e'),
   [NetworkEnum.UNICHAIN]: new Address('0x3c4758979ec30ca45857cabc2462a70699ed790e'),
   [NetworkEnum.SONIC]: new Address('0x3c4758979ec30ca45857cabc2462a70699ed790e'),
+  [NetworkEnum.ROBINHOOD]: new Address('0x3c4758979ec30ca45857cabc2462a70699ed790e'),
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Robinhood Chain support to both SDKs:

- `NetworkEnum.ROBINHOOD = 4663` in `@1inch/sdk-core`
- Aqua: `0x7c2d4aa5c900c08004fadb1c0d953c5b099fec86`
- AquaSwapVMRouter: `0x3c4758979ec30ca45857cabc2462a70699ed790e` (the redeployed v1.0.1 address, same as all other chains — NOT the outdated `0xa5368dd669...`)
- Updated the Supported Networks tables in both READMEs (explorer: robinhoodchain.blockscout.com)

Both addresses were verified on-chain via `eth_getCode` on `rpc.mainnet.chain.robinhood.com` (Aqua: 5,619 bytes of code, SwapVM: 20,379 bytes).

## Testing

- `pnpm build:contracts && pnpm build` — pass
- `pnpm lint`, `pnpm lint:types`, `pnpm test` — pass
- `FORK_URL=https://ethereum-rpc.publicnode.com pnpm test:e2e` — aqua 3/3 pass; swap-vm 10/13 pass, the 3 failures are the known fork-state-dependent exact-price assertions (13th-significant-digit drift, pre-existing and unrelated to this change)
- Verified built CJS bundles expose the new entries: `AQUA_CONTRACT_ADDRESSES[NetworkEnum.ROBINHOOD]` and `AQUA_SWAP_VM_CONTRACT_ADDRESSES[NetworkEnum.ROBINHOOD]` return the expected addresses
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcfa93f7-d204-4131-876e-f4ffb2d49d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcfa93f7-d204-4131-876e-f4ffb2d49d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

