### PR TITLE
feat: update SwapVM contract addresses after 2026-07-26 redeploy

### DIFF
--- a/typescript/swap-vm/README.md
+++ b/typescript/swap-vm/README.md
@@ -523,19 +523,19 @@ The SDK includes pre-configured contract addresses of `AquaSwapVMRouter` for the
 
 | Network | Chain ID | Address |
 |---------|----------|---------|
-| Ethereum | 1 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://etherscan.io/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| BNB Chain | 56 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://bscscan.com/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Polygon | 137 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://polygonscan.com/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Arbitrum | 42161 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://arbiscan.io/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Avalanche | 43114 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](http://snowscan.xyz/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Gnosis | 100 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://gnosisscan.io/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Coinbase Base | 8453 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://basescan.org/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Optimism | 10 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://optimistic.etherscan.io/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| zkSync Era | 324 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://era.zksync.network/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Linea | 59144 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://lineascan.build/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Unichain | 1301 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://uniscan.xyz/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Sonic | 146 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://sonicscan.org/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
-| Robinhood Chain | 4663 | [0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de](https://robinhoodchain.blockscout.com/address/0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de) |
+| Ethereum | 1 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://etherscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| BNB Chain | 56 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://bscscan.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Polygon | 137 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://polygonscan.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Arbitrum | 42161 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://arbiscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Avalanche | 43114 | [0x111111338c5091e8440b67b168bae16a668ac0de](http://snowscan.xyz/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Gnosis | 100 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://gnosisscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Coinbase Base | 8453 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://basescan.org/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Optimism | 10 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://optimistic.etherscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| zkSync Era | 324 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://era.zksync.network/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Linea | 59144 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://lineascan.build/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Unichain | 1301 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://uniscan.xyz/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Sonic | 146 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://sonicscan.org/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Robinhood Chain | 4663 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://robinhoodchain.blockscout.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 
 Access addresses using:
 

--- a/typescript/swap-vm/README.md
+++ b/typescript/swap-vm/README.md
@@ -533,7 +533,7 @@ The SDK includes pre-configured contract addresses of `AquaSwapVMRouter` for the
 | Optimism | 10 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://optimistic.etherscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | zkSync Era | 324 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://era.zksync.network/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | Linea | 59144 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://lineascan.build/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
-| Unichain | 1301 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://uniscan.xyz/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Unichain | 130 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://uniscan.xyz/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | Sonic | 146 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://sonicscan.org/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | Robinhood Chain | 4663 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://robinhoodchain.blockscout.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 

--- a/typescript/swap-vm/src/swap-vm-contract/constants.ts
+++ b/typescript/swap-vm/src/swap-vm-contract/constants.ts
@@ -6,29 +6,28 @@ import { Address, NetworkEnum } from '@1inch/sdk-core'
  * AquaSwapVMRouter contract addresses by chain ID
  * These addresses supports only AQUA instructions set
  *
- * Deployed with next params
- * - name    = `AquaSwapVMRouter`
- * - version = `1.0.1`
+ * Deployed with next EIP-712 domain params (per on-chain `eip712Domain()`)
+ * - name    = `1inch SwapVM v1.0`
+ * - version = `1.0.2`
  *
- * v1.0.1 is opcode-compatible with v1.0.0 (identical instruction ordering for
- * indices 0..32) and additionally registers the `onlyTxOriginTokenBalanceNonZero`
- * (tx.origin access-token / KYC gate) opcode.
+ * Supersedes the previous AquaSwapVMRouter deployment at
+ * `0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de` (all chains).
  *
- * @see https://github.com/1inch/swap-vm/blob/19cbd44/src/routers/AquaSwapVMRouter.sol#L11
+ * @see https://github.com/1inch/swap-vm/blob/fcca73f/src/routers/AquaSwapVMRouter.sol#L16
  * @see "../swap-vm/programs/aqua-program-builder"
  */
 export const AQUA_SWAP_VM_CONTRACT_ADDRESSES: Record<NetworkEnum, Address> = {
-  [NetworkEnum.ETHEREUM]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.BINANCE]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.POLYGON]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.ARBITRUM]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.AVALANCHE]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.GNOSIS]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.COINBASE]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.OPTIMISM]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.ZKSYNC]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.LINEA]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.UNICHAIN]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.SONIC]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
-  [NetworkEnum.ROBINHOOD]: new Address('0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de'),
+  [NetworkEnum.ETHEREUM]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.BINANCE]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.POLYGON]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.ARBITRUM]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.AVALANCHE]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.GNOSIS]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.COINBASE]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.OPTIMISM]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.ZKSYNC]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.LINEA]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.UNICHAIN]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.SONIC]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.ROBINHOOD]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Update SwapVM router address (2026-07-26 redeploy)

On 2026-07-26 the SwapVM router (`AquaSwapVMRouter`) was redeployed on **all chains** to a new vanity address (Ethereum deployment: block 25618917, 2026-07-26 18:59:23 UTC). The **Aqua registry address is unchanged** in this redeploy — `typescript/aqua/**` is intentionally untouched.

## New address

| Contract | Address |
|---|---|
| SwapVM router (`AquaSwapVMRouter`) | `0x111111338c5091e8440b67b168bae16a668ac0de` |

Replaces the superseded SwapVM router `0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de` (all 13 chains). Aqua stays at `0x1111113ccf1426a8e30e2bff5e005d929bf6a90a`.

## Changes

- `typescript/swap-vm/src/swap-vm-contract/constants.ts` — new SwapVM router address for all 13 networks, and the doc comment above `AQUA_SWAP_VM_CONTRACT_ADDRESSES` updated to match the on-chain reality (see below)
- `typescript/swap-vm/README.md` — Supported Networks table updated with the new address and explorer links (explorer domains unchanged)
- `typescript/swap-vm/README.md` — **drive-by documentation correction (pre-existing, not introduced by this PR):** the Unichain row listed chain ID `1301` (Unichain Sepolia); corrected to `130` (Unichain mainnet). `NetworkEnum.UNICHAIN = 130` in `typescript/sdk-core/src/types/chain.ts`, and the router bytecode is present on chain 130 but absent on chain 1301 (verified via `eth_getCode` on both). The explorer link already pointed at the mainnet explorer (`uniscan.xyz`; Sepolia lives on a separate subdomain), so it is unchanged.

> **Note:** `typescript/aqua/README.md` carries the same pre-existing `Unichain | 1301` row in its Supported Networks table. It is NOT changed here because `typescript/aqua/**` is out of scope for this PR — it should be fixed separately.

The root `README.md` and `typescript/README.md` contain no address mentions. A repo-wide search found no other occurrences of the old address; the only remaining hits are vendored Foundry broadcast records inside the `@1inch/swap-vm` npm dependency (under `contracts/lib/`), which are not part of this repo.

### Doc comment correction

The JSDoc previously claimed the deployment params were `name = AquaSwapVMRouter`, `version = 1.0.1` and described v1.0.1's opcode compatibility. Reading `eip712Domain()` on-chain shows those claims were already stale: the previous router (`0x…26c0de`) reports `name = "1inch SwapVM v1.0"`, `version = "1.0.2"`, and the new router reports the same (verified on Ethereum and Base; the `1.0.1` domain belonged to the older `0x3c4758…` deployment replaced in #84). The comment now records the verified EIP-712 `name`/`version` and the superseded router address. The v1.0.1-specific opcode-compatibility paragraph was removed rather than restated: the deployed contract is not source-verified on explorers, so opcode-level changes in this deployment could not be independently confirmed (note the new bytecode is 20,541 bytes vs 20,379 for the previous router, so the code did change). The `@see` link is pinned to `1inch/swap-vm@fcca73f` (main as of 2026-07-25, immediately before the redeploy) — best-effort, since the exact deployed commit cannot be confirmed without source verification.

## Verification

- New address verified on-chain via `eth_getCode` on all 13 supported networks (Ethereum, BNB, Polygon, Arbitrum, Avalanche, Gnosis, Base, Optimism, zkSync Era, Linea, Unichain, Sonic, Robinhood): bytecode present with identical size (**20,541 bytes**) on every chain.
- `eip712Domain()` on the new address returns `name = "1inch SwapVM v1.0"`, `version = "1.0.2"` (checked on Ethereum and Base).
- Ethereum deployment tx `0xc7eccb690b89094ab5ef0510164f2dd05a601f61449de45466fc855ccbb7d4cc`, block 25618917 (2026-07-26 18:59:23 UTC), via the deployer `0x0bd61d605c64a857c3d94779aef7ca295702b3a2`.
- Unichain chain ID check: `eth_getCode` returns the 20,541-byte router bytecode on chain 130 (Unichain mainnet) and empty code on chain 1301 (Unichain Sepolia).
- `pnpm build:contracts`, `pnpm build`, `pnpm lint`, `pnpm lint:types` — all pass (re-run after the chain-ID docs fix)
- Unit tests: `swap-vm` 600/600 passed, `aqua` 31/31 passed, `sdk-core` 57/57 passed
- e2e (Anvil mainnet fork via Docker, `FORK_URL=https://ethereum-rpc.publicnode.com`):
  - `aqua` e2e: **3/3 passed**
  - `swap-vm` e2e: **10/13 passed**; the 3 failures are the known-flaky exact floating-point price assertions (the 2000–3000 concentrated-range tests and the 30bps-fee test), differing at the ~13th significant digit (e.g. `2462.295934276742` vs expected `2462.2959342765034`) depending on fork block/RPC provider — pre-existing and unrelated to this change (the e2e suites deploy contracts locally and do not use the address constants; same 3 tests were flaky in #84).

## Release after merge

After this PR is merged, a new version of **`@1inch/swap-vm-sdk`** should be released via the **"Release typescript"** GitHub Actions workflow (dispatch for the `swap-vm` project). Not dispatched from this PR; do it only after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e866d3ee-bdae-4d74-8b4e-425b9fe76378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e866d3ee-bdae-4d74-8b4e-425b9fe76378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

