### PR TITLE
feat: add Monad (143), Cronos (25), HyperEVM (999)

### DIFF
--- a/typescript/aqua/README.md
+++ b/typescript/aqua/README.md
@@ -198,7 +198,7 @@ The SDK includes pre-configured contract addresses for the following networks:
 | Optimism | 10 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://optimistic.etherscan.io/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | zkSync Era | 324 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://era.zksync.network/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Linea | 59144 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://lineascan.build/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
-| Unichain | 1301 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://uniscan.xyz/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
+| Unichain | 130 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://uniscan.xyz/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Sonic | 146 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://sonicscan.org/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Robinhood Chain | 4663 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://robinhoodchain.blockscout.com/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Monad | 143 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://monadscan.com/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |

--- a/typescript/aqua/README.md
+++ b/typescript/aqua/README.md
@@ -201,6 +201,9 @@ The SDK includes pre-configured contract addresses for the following networks:
 | Unichain | 1301 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://uniscan.xyz/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Sonic | 146 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://sonicscan.org/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 | Robinhood Chain | 4663 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://robinhoodchain.blockscout.com/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
+| Monad | 143 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://monadscan.com/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
+| Cronos | 25 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://explorer.cronos.com/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
+| HyperEVM | 999 | [0x1111113ccf1426a8e30e2bff5e005d929bf6a90a](https://hyperevmscan.io/address/0x1111113ccf1426a8e30e2bff5e005d929bf6a90a) |
 
 Access addresses using:
 

--- a/typescript/aqua/package.json
+++ b/typescript/aqua/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/aqua-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1-rc.0",
   "description": "1inch Aqua Protocol SDK",
   "author": "@1inch",
   "license": "LicenseRef-Degensoft-Aqua-Source-1.1",

--- a/typescript/aqua/src/aqua-protocol-contract/constants.ts
+++ b/typescript/aqua/src/aqua-protocol-contract/constants.ts
@@ -19,4 +19,7 @@ export const AQUA_CONTRACT_ADDRESSES: Record<NetworkEnum, Address> = {
   [NetworkEnum.UNICHAIN]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
   [NetworkEnum.SONIC]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
   [NetworkEnum.ROBINHOOD]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
+  [NetworkEnum.MONAD]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
+  [NetworkEnum.CRONOS]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
+  [NetworkEnum.HYPEREVM]: new Address('0x1111113ccf1426a8e30e2bff5e005d929bf6a90a'),
 }

--- a/typescript/sdk-core/package.json
+++ b/typescript/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/sdk-core",
-  "version": "0.1.2",
+  "version": "0.1.3-rc.0",
   "description": "Core utilities and types for 1inch SDKs",
   "author": "@1inch",
   "repository": {

--- a/typescript/sdk-core/src/types/chain.ts
+++ b/typescript/sdk-core/src/types/chain.ts
@@ -12,4 +12,7 @@ export enum NetworkEnum {
   SONIC = 146,
   UNICHAIN = 130,
   ROBINHOOD = 4663,
+  MONAD = 143,
+  CRONOS = 25,
+  HYPEREVM = 999,
 }

--- a/typescript/swap-vm/README.md
+++ b/typescript/swap-vm/README.md
@@ -536,6 +536,9 @@ The SDK includes pre-configured contract addresses of `AquaSwapVMRouter` for the
 | Unichain | 130 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://uniscan.xyz/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | Sonic | 146 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://sonicscan.org/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 | Robinhood Chain | 4663 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://robinhoodchain.blockscout.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Monad | 143 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://monadscan.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| Cronos | 25 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://explorer.cronos.com/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
+| HyperEVM | 999 | [0x111111338c5091e8440b67b168bae16a668ac0de](https://hyperevmscan.io/address/0x111111338c5091e8440b67b168bae16a668ac0de) |
 
 Access addresses using:
 

--- a/typescript/swap-vm/package.json
+++ b/typescript/swap-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/swap-vm-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1-rc.0",
   "description": "1inch Swap VM SDK",
   "author": "@1inch",
   "license": "LicenseRef-Degensoft-SwapVM-1.1",

--- a/typescript/swap-vm/src/swap-vm-contract/constants.ts
+++ b/typescript/swap-vm/src/swap-vm-contract/constants.ts
@@ -8,7 +8,7 @@ import { Address, NetworkEnum } from '@1inch/sdk-core'
  *
  * Deployed with next EIP-712 domain params (per on-chain `eip712Domain()`)
  * - name    = `1inch SwapVM v1.0`
- * - version = `1.0.2`
+ * - version = `1.0.2` (the Monad, Cronos and HyperEVM deployments report `1.0`)
  *
  * Supersedes the previous AquaSwapVMRouter deployment at
  * `0x1111113db0e0ef9d0e3a50d5f094a3a57a26c0de` (all chains).
@@ -30,4 +30,7 @@ export const AQUA_SWAP_VM_CONTRACT_ADDRESSES: Record<NetworkEnum, Address> = {
   [NetworkEnum.UNICHAIN]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
   [NetworkEnum.SONIC]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
   [NetworkEnum.ROBINHOOD]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.MONAD]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.CRONOS]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
+  [NetworkEnum.HYPEREVM]: new Address('0x111111338c5091e8440b67b168bae16a668ac0de'),
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the EVM chains **Monad (143)**, **Cronos (25)** and **HyperEVM (999)** to the SDK monorepo, mirroring [#82](https://github.com/1inch/sdks/pull/82) (Robinhood Chain) on top of the post-redeploy universal addresses from [#86](https://github.com/1inch/sdks/pull/86):

- `@1inch/sdk-core`: `MONAD = 143`, `CRONOS = 25`, `HYPEREVM = 999` added to `NetworkEnum`.
- `@1inch/aqua-sdk`: Aqua Protocol address `0x1111113ccf1426a8e30e2bff5e005d929bf6a90a` mapped for all three chains + README network table rows.
- `@1inch/swap-vm-sdk`: `AquaSwapVMRouter` address `0x111111338c5091e8440b67b168bae16a668ac0de` mapped for all three chains + README network table rows.
- Drive-by docs fix: the aqua-sdk README listed Unichain with chain id `1301` (Unichain Sepolia); corrected to `130` to match `NetworkEnum.UNICHAIN`.

## Published rc pre-releases (from this branch, `next` dist-tag; `latest` untouched)

| Package | Version | Notes |
| --- | --- | --- |
| `@1inch/sdk-core` | `0.1.3-rc.0` | npmjs + GitHub Packages |
| `@1inch/aqua-sdk` | `0.3.1-rc.0` | pins `@1inch/sdk-core@0.1.3-rc.0` exactly |
| `@1inch/swap-vm-sdk` | `0.4.1-rc.0` | pins `@1inch/sdk-core@0.1.3-rc.0` exactly |

Published rc artifacts were installed from npmjs into a clean project and the new chain mappings verified. Final (non-rc) versions should be released from `master` after merge.

## On-chain verification (via `https://api.1inch.com/web3/{chainId}`)

For each of 143 / 25 / 999:

- `eth_chainId` matches.
- `eth_getCode` at the Aqua address returns 5,619 bytes of code; at the SwapVM router address 20,541 bytes — same sizes as on already-supported chains.
- SwapVM router `eip712Domain()`: name `1inch SwapVM v1.0` on all three chains. **Note:** the new deployments report domain **version `1.0`**, while existing chains (e.g. Ethereum, Sonic) report `1.0.2`. The SDK is unaffected (`Order.hash()` takes the domain as a parameter and the on-chain `eip712Domain()` is the source of truth), but the deployment-note comment in `swap-vm/src/swap-vm-contract/constants.ts` was updated to record this, and downstream consumers that hardcode `1.0.2` for EIP-712 signing will produce invalid hashes on these three chains.

## Testing

- `pnpm build`, `pnpm lint`, `pnpm lint:types`, `pnpm test` — all green for all 3 packages (also green in PR CI).
- Functional check of built CJS bundles and of the published rc packages: `NetworkEnum.{MONAD,CRONOS,HYPEREVM}` and both address maps resolve to the intake addresses.
- e2e (Anvil mainnet fork, `FORK_URL=https://ethereum-rpc.publicnode.com`): `aqua` 3/3 passed; `swap-vm` 10/13 passed — the 3 failures are the known fork-state float assertions (2000–3000 concentrated-range + 30bps-fee tests, ~13th significant digit) and fail identically on base `master` (verified in a clean worktree at `d126217`), i.e. unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57d71943-dca6-56e1-8d03-8d344628a81a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57d71943-dca6-56e1-8d03-8d344628a81a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

