### PR TITLE
ci: disable Trivy dependency scan on PRs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -41,15 +41,3 @@ jobs:
 
       - name: Test affected packages
         run: pnpm affected:test --base=origin/${{ github.base_ref }}
-
-  dependabot-audit:
-    uses: 1inch/workflows/.github/workflows/trivy-scan.yaml@trivy-scan-v1
-    permissions:
-      contents: read
-      actions: read
-      packages: read
-      security-events: write
-    with:
-      severity: 'CRITICAL'
-      limit-severities-for-sarif: false
-      skip-files: '.npmrc'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Disables the Trivy dependency scan in the `PR validation` workflow by removing the `dependabot-audit` job from `.github/workflows/pr-check.yml`.

That job called the shared `1inch/workflows/.github/workflows/trivy-scan.yaml@trivy-scan-v1` reusable workflow (introduced in `0b1c907`, DOPS-2535). The reusable workflow has no opt-out input, so removing the caller job is the only way to switch it off for this repository.

## Notes

- `master` has no branch protection rules or rulesets, so no required status check is left dangling by removing the job.
- The `check` job (build, lint, type-check, test) is unchanged; it is now the only job in `PR validation`.
- Re-enabling is a revert of this commit (or a restore of the block from `0b1c907`).

## Verification

- Workflow YAML parses; `jobs` now contains only `check`, and there are no remaining `trivy` references in the repository.
- The `PR validation` run on this PR is expected to show only the `check` job and no `dependabot-audit` / `Trivy Security Scan` job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-145bd91c-6ac5-4bab-915a-033db7922f30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-145bd91c-6ac5-4bab-915a-033db7922f30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

